### PR TITLE
Prevent id of property set to be text

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -124,7 +124,7 @@ MODx.grid.ElementProperties = function(config) {
                 ,elementId: config.elementId
                 ,elementType: config.elementType
             }
-            ,value: _('default')
+            ,value: 0
             ,listeners: {
                 'select': {fn:this.changePropertySet,scope:this}
             }


### PR DESCRIPTION
The id should be 0 if default properties are chosen. The value 0 properly shows "Default" text so we have no visible difference.
